### PR TITLE
fix: on header command, show only list of documents of this current p…

### DIFF
--- a/web/components/AppHeader/HeaderCommand.tsx
+++ b/web/components/AppHeader/HeaderCommand.tsx
@@ -55,7 +55,7 @@ export default function ProjectNavCommand() {
 	const [editorCommand, opts] = useUIStore(s => s.showEditorCommand);
 	const setShowEditorCommand = useUIStore(s => s.setShowEditorCommand);
 	const activeEditor = useLexicalEditorStore(s => s.activeEditor);
-	const { openDocument } = useDocumentTabs();
+	const { openDocument, activeDocument, projectId } = useDocumentTabs();
 
 	const [activeSubCommand, setActiveSubCommand] = useState<SubCommand>();
 
@@ -118,7 +118,6 @@ export default function ProjectNavCommand() {
 						/>
 						<CommandEmpty>
 							<p>No command found</p>
-							<Button> Hello</Button>
 						</CommandEmpty>
 						{
 							<>
@@ -191,13 +190,13 @@ export default function ProjectNavCommand() {
 						<CommandSeparator />
 						<CommandGroup heading="Open Project" className="mx-1 my-0.5">
 							{projectDocuments?.map(project => (
-								<CommandList
-									key={project.id}
-									onSelect={() => openProject(project.id)}
-								>
+								<CommandList key={project.id}>
 									<CommandItem
 										key={project.id}
-										onSelect={() => openProject(project.id)}
+										onSelect={() => {
+											openProject(project.id);
+											setShowEditorCommand(false);
+										}}
 									>
 										<Folder
 											size={15}
@@ -211,6 +210,7 @@ export default function ProjectNavCommand() {
 									</CommandItem>
 
 									{search &&
+										project.id === projectId &&
 										project.documents.map(doc => (
 											<CommandItem
 												key={doc.id}


### PR DESCRIPTION
- as per mentioned in the title, limit the document list on header to only the active project.
- reduce cluttering