### PR TITLE
Fix derived projectsLoadedAndEmpty value when projects is undefined

### DIFF
--- a/web/pages/editor/index.tsx
+++ b/web/pages/editor/index.tsx
@@ -113,7 +113,7 @@ const EditorPage = () => {
 		[sortedProjects],
 	);
 
-	const projectsLoadedAndEmpty = useMemo(() => !isGetProjectsLoading && projects?.length === 0, [
+	const projectsLoadedAndEmpty = useMemo(() => !isGetProjectsLoading && !projects?.length, [
 		isGetProjectsLoading,
 		projects,
 	]);


### PR DESCRIPTION
Fixes https://discord.com/channels/1085110924043616286/1178376846107217961/1193625229289861120

Properly handles instances where `projects` is undefined when deriving the value for projectsLoadedAndEmpty. Currently, it gets stuck on the page with a dropdown / sort selection, even when there's no project found