### PR TITLE
fix: Preserve table column cases on create table queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ create table projects (
   created_at timestamp default now(),
   title text,
   updated_at timestamp default now(),
-  userId uuid,
+  "userId" uuid,
   description text,
   emoji text,
-  sortingOrder smallint
+  "sortingOrder" smallint
 );
 
 create table chat_sessions (
@@ -154,7 +154,7 @@ create table documents (
   created_at timestamp default now(),
   text json,
   type text,
-  userId text,
+  "userId" text,
   title text not null,
   id uuid default uuid_generate_v4() primary key,
   projectId uuid,
@@ -164,8 +164,8 @@ create table documents (
 create table isaac_messages (
   id bigint not null primary key,
   created_at timestamp default now(),
-  userId uuid,
-  projectId uuid,
+  "userId" uuid,
+  "projectId" uuid,
   type character,
   content jsonb,
   updated_at timestamp default now()
@@ -193,7 +193,7 @@ create table profile (
 
 create table notes (
   id uuid default uuid_generate_v4() primary key,
-  projectId uuid references projects (id),
+  "projectId" uuid references projects (id),
   text json,
   created_at timestamp default now(),
   updated_at timestamp default now()
@@ -206,7 +206,7 @@ create table "references" (
   authors json,
   year text,
   doi text,
-  projectId uuid default uuid_generate_v4(),
+  "projectId" uuid default uuid_generate_v4(),
   tldr text,
   pdf text,
   updated_at timestamp default now(),
@@ -222,7 +222,7 @@ create table comments (
   quote text,
   type text,
   comments json[],
-  documentId text,
+  "documentId" text,
   created_at timestamp default now() not null,
   updated_at timestamp default now()
 );

--- a/supabase/migrations/20240109172445_local_dev.sql
+++ b/supabase/migrations/20240109172445_local_dev.sql
@@ -3,10 +3,10 @@ create table projects (
   created_at timestamp default now(),
   title text,
   updated_at timestamp default now(),
-  userId uuid,
+  "userId" uuid,
   description text,
   emoji text,
-  sortingOrder smallint
+  "sortingOrder" smallint
 );
 
 create table chat_sessions (
@@ -22,7 +22,7 @@ create table documents (
   created_at timestamp default now(),
   text json,
   type text,
-  userId text,
+  "userId" text,
   title text not null,
   id uuid default uuid_generate_v4() primary key,
   projectId uuid,
@@ -32,8 +32,8 @@ create table documents (
 create table isaac_messages (
   id bigint not null primary key,
   created_at timestamp default now(),
-  userId uuid,
-  projectId uuid,
+  "userId" uuid,
+  "projectId" uuid,
   type character,
   content jsonb,
   updated_at timestamp default now()
@@ -61,7 +61,7 @@ create table profile (
 
 create table notes (
   id uuid default uuid_generate_v4() primary key,
-  projectId uuid references projects (id),
+  "projectId" uuid references projects (id),
   text json,
   created_at timestamp default now(),
   updated_at timestamp default now()
@@ -74,7 +74,7 @@ create table "references" (
   authors json,
   year text,
   doi text,
-  projectId uuid default uuid_generate_v4(),
+  "projectId" uuid default uuid_generate_v4(),
   tldr text,
   pdf text,
   updated_at timestamp default now(),
@@ -90,7 +90,7 @@ create table comments (
   quote text,
   type text,
   comments json[],
-  documentId text,
+  "documentId" text,
   created_at timestamp default now() not null,
   updated_at timestamp default now()
 );


### PR DESCRIPTION
A lot of API requests when replicating locally are failing due to the incorrect cases of some columns (i.e. `userId` becomes `userid`). This PR wraps these camelCase columns around quotations to preserve their cases.

A more ideal fix would be to use consistent convention when naming the columns.