### PR TITLE
 fix: Preserve column casing of documents.projectId

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ create table documents (
   "userId" text,
   title text not null,
   id uuid default uuid_generate_v4() primary key,
-  projectId uuid,
+  "projectId" uuid,
   updated_at timestamp default now()
 );
 

--- a/supabase/migrations/20240109172445_local_dev.sql
+++ b/supabase/migrations/20240109172445_local_dev.sql
@@ -25,7 +25,7 @@ create table documents (
   "userId" text,
   title text not null,
   id uuid default uuid_generate_v4() primary key,
-  projectId uuid,
+  "projectId" uuid,
   updated_at timestamp default now()
 );
 


### PR DESCRIPTION
Preserve column casing of documents.projectId (similar to https://github.com/aietal/isaac/pull/80)