### PR TITLE
fix: redirect user to /editor when logging in with OAuth 2.0

### DIFF
--- a/web/app/api/auth/callback/route.ts
+++ b/web/app/api/auth/callback/route.ts
@@ -10,7 +10,7 @@ export async function GET(request) {
 		const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
 		await supabase.auth.exchangeCodeForSession(code);
 	}
-	const editorUrl = new URL('/editor', requestUrl);
+	const editorUrl = new URL('/editor', request.url);
 	// URL to redirect to after sign in process completes
 	return NextResponse.redirect(editorUrl.toString());
 }


### PR DESCRIPTION
fix request url ref

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 217866b51cb2d62009875421e24801405833a2a5.  | 
|--------|--------|

### Summary:
This PR fixes a bug in `route.ts` by correctly referencing the request's URL when creating a new URL instance for `editorUrl`.

**Key points**:
- Updated `route.ts` in `web/app/api/auth/callback`.
- Replaced `requestUrl` with `request.url` in the creation of `editorUrl`.
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
