### PR TITLE
fix: use inbuilt `redirect` from next/navigation

### DIFF
--- a/web/app/api/auth/callback/route.ts
+++ b/web/app/api/auth/callback/route.ts
@@ -1,6 +1,6 @@
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
-import { NextResponse } from 'next/server';
+import { redirect } from 'next/navigation'
 
 export async function GET(request) {
 	const requestUrl = new URL(request.url);
@@ -11,6 +11,5 @@ export async function GET(request) {
 		await supabase.auth.exchangeCodeForSession(code);
 	}
 	const editorUrl = new URL('/editor', request.url);
-	// URL to redirect to after sign in process completes
-	return NextResponse.redirect(editorUrl.toString());
+	redirect(editorUrl.toString());
 }


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit f1945afa13d066c6ab015ab1b93a569103093154.  | 
|--------|--------|

### Summary:
This PR replaces the `NextResponse.redirect` method with the `redirect` method from `next/navigation` in the `GET` function of the `route.ts` file.

**Key points**:
- Replaced `NextResponse.redirect` with `redirect` from `next/navigation` in `GET` function.
- The change is in the `route.ts` file under the `/web/app/api/auth/callback/` directory.
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
