### PR TITLE
fix: use native response redirect tested locally

### DIFF
--- a/web/app/api/auth/callback/route.ts
+++ b/web/app/api/auth/callback/route.ts
@@ -1,6 +1,5 @@
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation'
 
 export async function GET(request) {
 	const requestUrl = new URL(request.url);
@@ -10,6 +9,10 @@ export async function GET(request) {
 		const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
 		await supabase.auth.exchangeCodeForSession(code);
 	}
-	const editorUrl = new URL('/editor', request.url);
-	redirect(editorUrl.toString());
+	return new Response(null, {
+			status: 302,
+			headers: {
+					Location: '/editor'
+			}
+	})
 }


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 558b0f6d6d851b4833972c11917a019032e7c8a2.  | 
|--------|--------|

### Summary:
This PR simplifies the redirect process in the `GET` function of `/web/app/api/auth/callback/route.ts` by using the native `Response` object instead of `redirect` from `next/navigation`.

**Key points**:
- Removed `redirect` import from `next/navigation` in `/web/app/api/auth/callback/route.ts`
- Modified `GET` function to use native `Response` for redirect
- Set status code to 302 and `Location` header to '/editor'
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
